### PR TITLE
Fixed wrong class name Backend\Models\UserPreference

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -5,7 +5,6 @@ use Backend\Classes\Controller as BackendController;
 use Event;
 use Backend;
 use BackendAuth;
-use Backend\Models\UserPreferences;
 use File;
 use BackendMenu;
 
@@ -172,8 +171,12 @@ class Plugin extends PluginBase
 
         BackendController::extend(function($controller)
         {
+            $preferenceModel = class_exists('Backend\Models\UserPreference')
+                ? Backend\Models\UserPreference::forUser()
+                : Backend\Models\UserPreferences::forUser();
+            
             if (BackendAuth::check()) {
-                $preferences = UserPreferences::forUser()->get('backend::backend.preferences');
+                $preferences = $preferenceModel->get('backend::backend.preferences');
 
                 if (isset($preferences['focus_searchfield']) && $preferences['focus_searchfield']) {
                     $controller->addJs('/plugins/indikator/backend/assets/js/setting-search.js');

--- a/partials/_settings_menu_items.htm
+++ b/partials/_settings_menu_items.htm
@@ -5,8 +5,11 @@
         isset($_COOKIE['sidenav_treegroupStatus']) ? $_COOKIE['sidenav_treegroupStatus'] : null
     );
 
-    use Backend\Models\UserPreferences;
-    $preferences = UserPreferences::forUser()->get('backend::backend.preferences');
+    $preferenceModel = class_exists('Backend\Models\UserPreference')
+        ? Backend\Models\UserPreference::forUser()
+        : Backend\Models\UserPreferences::forUser();
+
+    $preferences = $preferenceModel->get('backend::backend.preferences');
 ?>
 <ul class="top-level">
     <?php foreach ($items as $category => $items):


### PR DESCRIPTION
This fixes issue #6 

After logging in to the backend a `Class 'Indikator\Backend\UserPreference' not found` exception is thrown on October CMS build 346.
