### PR TITLE
If not utf-8, json return false

### DIFF
--- a/reportwidgets/Server.php
+++ b/reportwidgets/Server.php
@@ -50,5 +50,8 @@ class Server extends ReportWidgetBase
         $this->vars['host'] = php_uname('n');
         $this->vars['ip']   = $_SERVER['SERVER_ADDR'];
         $this->vars['os']   = php_uname('s');
+        foreach ($this->vars as $key=>$item){
+            $this->vars[$key] = utf8_encode($this->vars[$key]);
+        }
     }
 }


### PR DESCRIPTION
"The Response content must be a string or object implementing __toString(), "boolean" given." on line 399 of \vendor\symfony\http-foundation\Response.php
